### PR TITLE
fix typo: comminations to communication

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -9,7 +9,7 @@
     <link rel="apple-touch-icon" href="./apple.png" />
     <meta
       name="description"
-      content="Urbanism for Web: improve human comminations by changing public
+      content="Urbanism for Web: improve human communication by changing public
       platforms"
     />
     <link
@@ -29,7 +29,7 @@
         </div>
         <h1 itemprop="name"><strong>h+h</strong> lab</h1>
         <p>
-          Urbanism for Web: improve human comminations by changing public
+          Urbanism for Web: improve human communication by changing public
           platforms.
         </p>
         <p>


### PR DESCRIPTION
This PR fixes typo in word `comminations`.

Note: I decided to use `communication` instead of `communications` based on their definitions in the Cambridge Dictionary.

- [Communication](https://dictionary.cambridge.org/dictionary/essential-american-english/communication): the act of communicating with other people
- [Communications](https://dictionary.cambridge.org/dictionary/essential-american-english/communications): the different ways of sending information between people and places, such as mail, telephones, computers, and radio.

I believe that `communication` is more correct here. The context here is that the goal is to improve communication between people as a whole, as opposed to improving a separate means to communicate.
